### PR TITLE
[Metrics Generator] Allow running on a different source of data

### DIFF
--- a/modules/generator/encoding.go
+++ b/modules/generator/encoding.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"iter"
+
+	"github.com/grafana/tempo/pkg/ingest"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// codec is the interface used to convert data from Kafka records to the
+// tempopb.PushSpansRequest expected by the generator processors.
+type codec interface {
+	decode([]byte) (iter.Seq2[*tempopb.PushSpansRequest, error], error)
+}
+
+// tempoDecoder unmarshals tempopb.PushBytesRequest.
+type tempoDecoder struct {
+	dec *ingest.Decoder
+}
+
+func newTempoDecoder() *tempoDecoder {
+	return &tempoDecoder{dec: ingest.NewDecoder()}
+}
+
+// decode implements codec.
+func (d *tempoDecoder) decode(data []byte) (iter.Seq2[*tempopb.PushSpansRequest, error], error) {
+	d.dec.Reset()
+	spanBytes, err := d.dec.Decode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	trace := tempopb.Trace{}
+	return func(yield func(*tempopb.PushSpansRequest, error) bool) {
+		for _, tr := range spanBytes.Traces {
+			trace.Reset()
+			err = trace.Unmarshal(tr.Slice)
+			yield(&tempopb.PushSpansRequest{Batches: trace.ResourceSpans}, err)
+		}
+	}, nil
+}
+
+// otlpDecoder unmarshals ptrace.Traces.
+type otlpDecoder struct {
+	trace tempopb.Trace
+}
+
+func newOTLPDecoder() *otlpDecoder {
+	return &otlpDecoder{trace: tempopb.Trace{}}
+}
+
+// decode implements codec.
+func (d *otlpDecoder) decode(data []byte) (iter.Seq2[*tempopb.PushSpansRequest, error], error) {
+	d.trace.ResourceSpans = d.trace.ResourceSpans[:0]
+	err := d.trace.Unmarshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(yield func(*tempopb.PushSpansRequest, error) bool) {
+		yield(&tempopb.PushSpansRequest{Batches: d.trace.ResourceSpans}, nil)
+	}, nil
+}

--- a/modules/generator/encoding_test.go
+++ b/modules/generator/encoding_test.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util/test"
+)
+
+func BenchmarkOTLPDecoder(b *testing.B) {
+	traceBytes := marshalBatches(b, []*v1.ResourceSpans{
+		test.MakeBatch(15, []byte("test batch 1")),
+		test.MakeBatch(50, []byte("test batch 2")),
+		test.MakeBatch(42, []byte("test batch 3")),
+	})
+
+	b.ReportAllocs()
+	decoder := newOTLPDecoder()
+	for i := 0; i < b.N; i++ {
+		reqs, err := decoder.decode(traceBytes)
+		require.NoError(b, err)
+		for _, _ = range reqs {
+		}
+	}
+}
+
+func marshalBatches(t testing.TB, batches []*v1.ResourceSpans) []byte {
+	t.Helper()
+
+	trace := tempopb.Trace{ResourceSpans: batches}
+
+	m, err := trace.Marshal()
+	require.NoError(t, err)
+
+	return m
+}

--- a/modules/generator/generator_test.go
+++ b/modules/generator/generator_test.go
@@ -60,6 +60,7 @@ overrides:
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), o))
 
 	generatorConfig := &Config{}
+	generatorConfig.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.ContinueOnError))
 	generatorConfig.Storage.Path = t.TempDir()
 	generatorConfig.Ring.KVStore.Store = "inmemory"
 	generatorConfig.Processor.SpanMetrics.RegisterFlagsAndApplyDefaults("", nil)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -53,10 +53,6 @@ var tracer = otel.Tracer("modules/ingester")
 
 const (
 	ingesterRingKey = "ring"
-
-	// PartitionRingKey is the key under which we store the partitions ring used by the "ingest storage".
-	PartitionRingKey  = "ingester-partitions"
-	PartitionRingName = "ingester-partitions"
 )
 
 // Ingester builds blocks out of incoming traces
@@ -130,7 +126,7 @@ func New(cfg Config, store storage.Store, overrides overrides.Interface, reg pro
 
 		partitionRingKV := cfg.IngesterPartitionRing.KVStore.Mock
 		if partitionRingKV == nil {
-			partitionRingKV, err = kv.NewClient(cfg.IngesterPartitionRing.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(reg, PartitionRingName+"-lifecycler"), log.Logger)
+			partitionRingKV, err = kv.NewClient(cfg.IngesterPartitionRing.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(reg, ingest.PartitionRingName+"-lifecycler"), log.Logger)
 			if err != nil {
 				return nil, fmt.Errorf("creating KV store for ingester partition ring: %w", err)
 			}
@@ -138,8 +134,8 @@ func New(cfg Config, store storage.Store, overrides overrides.Interface, reg pro
 
 		i.ingestPartitionLifecycler = ring.NewPartitionInstanceLifecycler(
 			i.cfg.IngesterPartitionRing.ToLifecyclerConfig(i.ingestPartitionID, cfg.LifecyclerConfig.ID),
-			PartitionRingName,
-			PartitionRingKey,
+			ingest.PartitionRingName,
+			ingest.PartitionRingKey,
 			partitionRingKV,
 			log.Logger,
 			prometheus.WrapRegistererWithPrefix("cortex_", reg))

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -32,6 +32,10 @@ const (
 	// in the worst case scenario, which is expected to be way above the actual one.
 	maxProducerRecordDataBytesLimit = producerBatchMaxBytes - 16384
 	minProducerRecordDataBytesLimit = 1024 * 1024
+
+	// PartitionRingKey is the key under which we store the partitions ring used by the "ingest storage".
+	PartitionRingKey  = "ingester-partitions"
+	PartitionRingName = "ingester-partitions"
 )
 
 var (
@@ -44,12 +48,14 @@ var (
 )
 
 type Config struct {
-	Enabled bool        `yaml:"enabled"`
-	Kafka   KafkaConfig `yaml:"kafka"`
+	Enabled         bool        `yaml:"enabled"`
+	Kafka           KafkaConfig `yaml:"kafka"`
+	OverrideRingKey string      `yaml:"override_ring_key"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(_ string, f *flag.FlagSet) {
 	cfg.Kafka.RegisterFlags(f)
+	cfg.OverrideRingKey = PartitionRingKey
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/ingest/reader_client.go
+++ b/pkg/ingest/reader_client.go
@@ -57,7 +57,7 @@ func NewGroupReaderClient(kafkaCfg KafkaConfig, partitionRing ring.PartitionRing
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.Balancers(NewCooperativeActiveStickyBalancer(partitionRing)),
-		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.ConsumeResetOffset(kgo.NoResetOffset().AtEnd()),
 	)
 
 	client, err := NewReaderClient(kafkaCfg, metrics, logger, opts...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This allows configuring metrics generator to run off a second source of data that's separate from Tempo's ingester partition ring.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`